### PR TITLE
Add python login example

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,4 +237,5 @@ $ vault write auth/ssh/login role=ubuntu public_key=@id_rsa.pub $(createsig id_r
 ### Using ssh-agent
 
 Signatures can also be created using ssh-agent.
-See the [vssh README](vssh/README.md) for an example of how to do that.
+See the [vssh README](vssh/README.md) and [pylogin README](pylogin/README.md)
+for examples of how to do that.

--- a/pylogin/README.md
+++ b/pylogin/README.md
@@ -1,0 +1,34 @@
+# pylogin
+
+This is a python code example which uses vault-plugin-auth-ssh set up
+with ssh public keys in ssh-agent to get a vault token.
+
+Requirements:
+
+- ssh-agent which contains your ssh public key or keys.
+- $VAULT_ADDR which contains the URL to your vault server.
+- python3, including the paramiko module (installable for example
+  through pip).
+
+If there are multiple keys in ssh-agent it will try each until success.
+If successful, stdout will have the json response including the vault
+token.  You can extract it by piping it to `jq -r .auth.client_token`.
+
+The "-V" option will show the parameters it is sending to vault, and
+metadata keys and values may optionally be passed.
+
+## Example
+
+Create a role `yourrole` which with known public_key and gives you the
+`apolicy` policy on this token.  This has to be done using a privileged
+vault token.
+
+```
+$ vault write auth/ssh/role/yourrole token_policies="apolicy" public_keys=@id_rsa.pub
+```
+
+Now run login.py giving the role name and piping to jq:
+```
+$ ./login.py yourrole | jq -r .auth.client_token
+s.j0Sf3qCXxMRDqXXxWpxBuwgm
+```

--- a/pylogin/login.py
+++ b/pylogin/login.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# Example python program to login to vault-plugin-auth-ssh using ssh-agent
+# $VAULT_ADDR must be set, and role passed as an argument
+
+import sys
+import os
+import base64
+import struct
+import json
+import urllib.request
+import paramiko
+
+def usage():
+    print("Usage: " + me + " [-V] role [metadatakey=value ...]", file=sys.stderr)
+    print(" -V: verbose, show data sent to vault", file=sys.stderr)
+    sys.exit(1)
+
+def main():
+    argv = sys.argv
+    global me
+    me = sys.argv[0]
+    verbose = False
+    if len(argv) > 1:
+        if argv[1] == "-V":
+            verbose = True
+            argv = argv[1:]
+        elif argv[1][0] == '-':
+            print(me + ': unknown option: ' + argv[1], file=sys.stderr)
+            usage()
+    if len(argv) < 2:
+        usage()
+    role = argv[1]
+
+    vault = os.getenv("VAULT_ADDR")
+    if vault is None:
+        print("$VAULT_ADDR not set", file=sys.stderr)
+        sys.exit(2)
+
+    agent = paramiko.Agent()
+    agent_keys = agent.get_keys()
+    if len(agent_keys) == 0:
+        print("No ssh agent keys found", file=sys.stderr)
+        sys.exit(2)
+
+    metadata = {}
+    for arg in argv[2:]:
+        parts = arg.split('=')
+        if len(parts) > 1:
+            metadata[parts[0]] = parts[1]
+
+    errmsgs = []
+    for key in agent_keys:
+        with urllib.request.urlopen(vault + "/v1/auth/ssh/nonce") as response:
+            body = response.read()
+        data = json.loads(body)
+        nonce = data["data"]["nonce"]
+        b64nonce = base64.b64encode(nonce.encode()).decode()
+
+        d = key.sign_ssh_data(nonce)
+        parts = []
+        while d:
+            ln = struct.unpack('>I', d[:4])[0]
+            bits = d[4:ln+4]
+            parts.append(bits)
+            d = d[ln+4:]
+        sig = parts[1]
+        b64sig = base64.b64encode(sig).decode()
+
+        pubkey = key.get_name() + ' ' + key.get_base64() + ' x'
+        data = {
+            'role': role,
+            'public_key': pubkey,
+            'signature': b64sig,
+            'nonce': b64nonce,
+        }
+        if metadata != {}:
+            data['metadata'] = metadata
+
+        datastr = json.dumps(data, indent=4, sort_keys=True)
+        if verbose:
+            print("-- Attempting login with\n" + datastr + "\n--", file=sys.stderr)
+
+        req = urllib.request.Request(vault + "/v1/auth/ssh/login", datastr.encode())
+        try:
+            with urllib.request.urlopen(req) as response:
+                body = response.read()
+        except Exception as e:
+            typ = type(e).__name__
+            msg = typ + ': ' + str(e)
+            if typ == 'HTTPError':
+                errmsg = e.read().decode()
+                try:
+                    decoded = json.loads(errmsg)
+                    if 'errors' in decoded:
+                        errmsg = ':'
+                        for error in decoded['errors']:
+                            errmsg += ' ' + error
+                except:
+                    errmsg = ' ' + errmsg
+                msg += errmsg
+            if verbose:
+                print('Login attempt failed: ' + msg, file=sys.stderr)
+            else:
+                errmsgs.append(msg)
+            continue
+
+        data = json.loads(body)
+        print(json.dumps(data, indent=4, sort_keys=True))
+
+        sys.exit(0)
+
+    for msg in errmsgs:
+        print('Login failed: ' + msg, file=sys.stderr)
+    sys.exit(1)
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
This PR adds a python example to log in using public keys in ssh-agent.  It uses the nonce API from #10 so that should be merged first.

I expect this could be easily extended to use ssh certs as well, but I don't use them so I wouldn't know how to test it.
