### PR TITLE
Support configured default token parameters, public key self-registration

### DIFF
--- a/path_role.go
+++ b/path_role.go
@@ -189,6 +189,13 @@ func (b *backend) pathRoleCreateUpdate(ctx context.Context, req *logical.Request
 		}
 
 		role = new(sshRole)
+
+		// set defaults for token parameters
+		config, err := b.config(ctx, req.Storage)
+		if err != nil {
+			return nil, err
+		}
+		role.TokenParams = config.TokenParams
 	}
 
 	if publicKeys, ok := data.GetOk("public_keys"); ok {


### PR DESCRIPTION
This add support for all the token parameters to the config path, to be used as defaults if not overridden in a role.

In addition, it documents how to make a policy for a separate authentication method to take advantage of this for SSH public key self-registration.