### PR TITLE
Add extended principals support

### DIFF
--- a/path_role.go
+++ b/path_role.go
@@ -41,7 +41,7 @@ func (b *backend) pathRole() *framework.Path {
 			},
 			"principals": {
 				Type:        framework.TypeCommaStringSlice,
-				Description: "Principals allowed for this role.",
+				Description: "Principals allowed for this role. A * means every principal is accepted.",
 			},
 		},
 		ExistenceCheck: b.pathRoleExistenceCheck,


### PR DESCRIPTION
Support adding a role that allows any principal. This allows for
scenarios where a single role accepts all certificates signed by a CA,
and that vault identity aliases or policy templating are used later to
restrict access to the users. For this, we also need to include a
principal name in the logical.Alias identity, rather than supplying
just the role name. But of course, a certificate can list multiple valid
principals, and users must be able to select their preferred principal.
For this, the username field is added to the login path.

Signed-off-by: Peter Verraedt <peter.verraedt@kuleuven.be>