### PR TITLE
Allow `@` in role names

### DIFF
--- a/path_role.go
+++ b/path_role.go
@@ -29,7 +29,7 @@ func (b *backend) pathRoleList() *framework.Path {
 // pathRole returns the path configurations for the CRUD operations on roles
 func (b *backend) pathRole() *framework.Path {
 	p := &framework.Path{
-		Pattern: "role/" + framework.GenericNameRegex("name"),
+		Pattern: "role/" + framework.GenericNameWithAtRegex("name"),
 		Fields: map[string]*framework.FieldSchema{
 			"name": {
 				Type:        framework.TypeLowerCaseString,


### PR DESCRIPTION
We have a need to use email addresses as role names in some cases, so this adds `@` to the allowed characters of the role.