### PR TITLE
Forward nonce and login requests to the active node

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -44,11 +44,15 @@ func (b *backend) pathLogin() *framework.Path {
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.handleLogin,
-				Summary:  "Log in using ssh certificates",
+				Callback:                    b.handleLogin,
+				Summary:                     "Log in using ssh certificates",
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 			logical.AliasLookaheadOperation: &framework.PathOperation{
-				Callback: b.handleLogin,
+				Callback:                    b.handleLogin,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 		},
 	}

--- a/path_nonce.go
+++ b/path_nonce.go
@@ -17,6 +17,10 @@ func (b *backend) pathNonce() *framework.Path {
 				Callback: b.pathNonceRead,
 				Summary:  "Generates a new nonce",
 			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathNonceRead,
+				Summary:  "Generates a new nonce",
+			},
 		},
 	}
 }

--- a/path_nonce.go
+++ b/path_nonce.go
@@ -14,12 +14,10 @@ func (b *backend) pathNonce() *framework.Path {
 		Pattern: "nonce$",
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
-				Callback: b.pathNonceRead,
-				Summary:  "Generates a new nonce",
-			},
-			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathNonceRead,
-				Summary:  "Generates a new nonce",
+				Callback:                    b.pathNonceRead,
+				Summary:                     "Generates a new nonce",
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 		},
 	}


### PR DESCRIPTION
In an Enterprise HA cluster with performance standbys that use a load balancer, read and login requests are distributed over all nodes and only actions that modify the underlaying (Raft) storage are forwarded to the leader. Since login is a two-step process, there is a high probability that the login request will not go to the node where the nonce was created, yielding an error because login verifies that the nonce is in its internal cache of generated nonces.

This change adds modifiers to the paths exposed by the SSH auth plugin that always forwards requests to read a nonce and to login to the active node, even if they originally landed on a performance standby).

In a single node cluster, this is a NOP.
In a community edition HA cluster, this is a NOP because there all requests (even read requests) get forwarded to the active node anyway,.
In an enterprise edition HA cluster, this allows the SSH auth plugin to work reliably.